### PR TITLE
Upgraded CentCom "security," cut back on loot spawners

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3327,6 +3327,7 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/supply)
 "iG" = (
+/obj/effect/forcefield/centcom_dock,
 /turf/closed/indestructible/fakedoor{
 	name = "CentCom Warehouse"
 	},
@@ -3490,6 +3491,7 @@
 "jb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plating,
 /area/centcom/supply)
 "jc" = (
@@ -3584,6 +3586,7 @@
 	dir = 4;
 	id = "XCCQMLoad2"
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "jl" = (
@@ -3783,6 +3786,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "jJ" = (
@@ -5467,6 +5471,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 29
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "nj" = (
@@ -5647,6 +5652,7 @@
 /area/syndicate_mothership/control)
 "nA" = (
 /obj/structure/sign/warning/nosmoking,
+/obj/effect/forcefield/centcom_dock,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "nB" = (
@@ -6923,6 +6929,7 @@
 "pB" = (
 /obj/machinery/light/floor,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "pC" = (
@@ -7109,6 +7116,7 @@
 /area/centcom/supplypod/loading/ert)
 "pU" = (
 /obj/structure/sign/departments/drop,
+/obj/effect/forcefield/centcom_dock,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "pV" = (
@@ -8484,6 +8492,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "sE" = (
@@ -8575,6 +8584,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "sI" = (
@@ -8747,6 +8757,7 @@
 "tc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/light/floor,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "td" = (
@@ -8833,6 +8844,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "tn" = (
@@ -9965,12 +9977,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"vr" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/snowdin/weaponrymid,
-/obj/effect/spawner/lootdrop/snowdin/weaponrymid,
-/turf/open/floor/carpet,
-/area/centcom/evac)
 "vs" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -10034,6 +10040,7 @@
 	icon_state = "doors";
 	name = "WARNING: EXTERNAL AIRLOCK"
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "vB" = (
@@ -10430,6 +10437,7 @@
 /area/centcom/evac)
 "wk" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
 "wl" = (
@@ -11320,7 +11328,6 @@
 /obj/item/newspaper,
 /obj/effect/spawner/lootdrop/snowdin/weaponryheavy,
 /obj/effect/spawner/lootdrop/snowdin/weaponrymid,
-/obj/item/grenade/clusterbuster/slime/volatile,
 /turf/open/floor/holofloor/wood,
 /area/centcom/evac)
 "yj" = (
@@ -11359,6 +11366,7 @@
 "yn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plating,
 /area/centcom/ferry)
 "yo" = (
@@ -11664,17 +11672,6 @@
 	dir = 1
 	},
 /area/centcom/evac)
-"yT" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/snowdin/weaponrymid,
-/obj/effect/spawner/lootdrop/snowdin/weaponrylite,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
-/area/centcom/evac)
 "yU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -11806,7 +11803,6 @@
 	},
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/snowdin/weaponrymid,
-/obj/effect/spawner/lootdrop/snowdin/weaponrylite,
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
@@ -13089,6 +13085,10 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"BU" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/prison)
 "BV" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/closed/indestructible{
@@ -13656,6 +13656,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"CW" = (
+/obj/machinery/status_display/evac,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/control)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -13821,6 +13826,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "Dr" = (
@@ -15155,6 +15161,10 @@
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
+"GB" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/supply)
 "GC" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -16410,6 +16420,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
+"IO" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeadmin)
 "IP" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -16966,6 +16980,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"Ke" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Shuttle";
+	req_access_txt = "106"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/forcefield/centcom_dock,
+/turf/open/floor/plasteel,
+/area/centcom/supply)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -16988,6 +17013,7 @@
 	name = "Backup Emergency Escape Shuttle"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
 "Kk" = (
@@ -17002,6 +17028,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"Km" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "Kn" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -17249,6 +17279,7 @@
 /area/tdome/tdomeadmin)
 "KC" = (
 /obj/machinery/status_display/evac,
+/obj/effect/forcefield/centcom_dock,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeadmin)
 "KD" = (
@@ -17895,6 +17926,11 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"MQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/forcefield/centcom_dock,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "MR" = (
 /obj/machinery/light{
 	dir = 4
@@ -18035,7 +18071,6 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/snowdin/weaponrylite,
 /obj/effect/spawner/lootdrop/snowdin/weaponrymid,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
@@ -18081,6 +18116,12 @@
 "OA" = (
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
+"OF" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/fakedoor{
+	name = "Thunderdome Admin"
+	},
+/area/tdome/tdomeadmin)
 "OG" = (
 /obj/structure/dresser,
 /obj/machinery/light{
@@ -18088,6 +18129,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"OI" = (
+/obj/machinery/status_display/ai,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/control)
 "OP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -18271,6 +18317,14 @@
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
+"Qn" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/supplypod)
+"Qr" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
 "Qu" = (
 /obj/machinery/vr_sleeper{
 	dir = 8
@@ -18400,6 +18454,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Rr" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "Ru" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18419,6 +18478,11 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
+"RB" = (
+/obj/structure/sign/nanotrasen,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "RM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18428,6 +18492,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"RP" = (
+/obj/structure/sign/nanotrasen,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/control)
 "RS" = (
 /obj/machinery/light{
 	dir = 8
@@ -18439,6 +18508,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"RY" = (
+/obj/machinery/status_display/evac,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/supply)
 "Sd" = (
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
@@ -18660,6 +18734,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Uk" = (
+/obj/machinery/status_display/supply,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/supply)
 "Um" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/shovel/spade,
@@ -18693,6 +18772,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Up" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/forcefield/centcom_dock,
+/turf/open/floor/plating,
+/area/centcom/ferry)
 "Uw" = (
 /obj/machinery/light{
 	dir = 8
@@ -18739,6 +18823,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"UR" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/open/space/basic,
+/area/space)
 "UT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -18749,6 +18837,11 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UW" = (
+/obj/structure/sign/warning/securearea,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "UY" = (
 /obj/effect/spawner/template/infiltrator,
 /turf/open/space/basic,
@@ -18807,6 +18900,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"VG" = (
+/obj/machinery/status_display/evac,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "VH" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -18916,6 +19014,15 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"WZ" = (
+/obj/machinery/status_display/ai,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
+"Xb" = (
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/control)
 "Xd" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -18995,6 +19102,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "XD" = (
@@ -19006,6 +19114,7 @@
 /area/centcom/supplypod/loading/one)
 "XK" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/effect/forcefield/centcom_dock,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
 "XL" = (
@@ -19018,10 +19127,23 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"XR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/forcefield/centcom_dock,
+/turf/open/floor/plating,
+/area/centcom/supply)
 "Ya" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Yc" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/forcefield/centcom_dock,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
 "Yf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chawanmushi,
@@ -19131,6 +19253,11 @@
 "Zc" = (
 /turf/open/indestructible/binary,
 /area/space)
+"Ze" = (
+/obj/machinery/status_display/ai,
+/obj/effect/forcefield/centcom_dock,
+/turf/closed/indestructible/riveted,
+/area/centcom/supply)
 "Zh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -50251,13 +50378,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UR
+UR
+UR
+UR
+UR
+UR
+UR
 aa
 aa
 aa
@@ -50508,13 +50635,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -50765,13 +50892,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -51022,13 +51149,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -51279,13 +51406,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -51536,13 +51663,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -51793,13 +51920,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -52050,13 +52177,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -52307,13 +52434,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -52564,13 +52691,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -52821,13 +52948,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -53078,13 +53205,13 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -53329,19 +53456,19 @@ aa
 aa
 aa
 aa
-oe
-oe
-nT
-nU
-oe
-oe
+Up
+Up
+WZ
+VG
+Up
+Up
+UR
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -53587,18 +53714,18 @@ aa
 aa
 aa
 aa
-oe
+Up
 rk
 sq
 to
 uj
-oe
+Up
 aa
 pz
 pA
 pz
 aa
-aa
+UR
 aa
 aa
 aa
@@ -53844,17 +53971,18 @@ aa
 aa
 aa
 aa
-mD
+Km
 rl
 sr
 tp
 uk
-mD
+Km
 pz
-oe
+Up
 xc
-oe
+Up
 pz
+UR
 aa
 aa
 aa
@@ -53863,10 +53991,9 @@ aa
 aa
 aa
 aa
-aa
-oe
+Up
 td
-oe
+Up
 aa
 aa
 aa
@@ -54101,31 +54228,31 @@ aa
 aa
 aa
 aa
-oe
+Up
 rm
 ss
 tq
 ul
-mD
+Km
 vA
-oe
+Up
 xd
-oe
+Up
 yn
-mD
+Km
 pB
-oe
+Up
 pU
-oe
+Up
 pB
-mD
-mD
-mD
-oe
+Km
+Km
+Km
+Up
 xd
-oe
-oe
-mD
+Up
+Up
+Km
 aa
 aa
 aa
@@ -54358,18 +54485,18 @@ aa
 aa
 aa
 aa
-oe
+Up
 rn
 st
 tr
 um
 nT
 vB
-oe
+Up
 Xy
-oe
+Up
 oU
-nU
+VG
 wB
 xe
 xe
@@ -54382,7 +54509,7 @@ tc
 tm
 tc
 vB
-oe
+Up
 aa
 aa
 aa
@@ -54615,7 +54742,7 @@ aa
 aa
 aa
 aa
-nU
+VG
 ro
 su
 ts
@@ -54626,7 +54753,7 @@ wr
 xe
 wr
 wx
-mD
+Km
 pC
 pT
 pT
@@ -54639,7 +54766,7 @@ xe
 xe
 xe
 wx
-oe
+Up
 aa
 aa
 aa
@@ -54872,7 +54999,7 @@ aa
 aa
 aa
 aa
-oe
+Up
 rp
 su
 ts
@@ -54896,7 +55023,7 @@ rb
 rb
 rb
 yp
-oe
+Up
 aa
 aa
 aa
@@ -55129,7 +55256,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 rq
 sv
 tt
@@ -55140,7 +55267,7 @@ wt
 xg
 wt
 px
-mD
+Km
 pD
 pX
 pX
@@ -55153,7 +55280,7 @@ wt
 qF
 wt
 wz
-oe
+Up
 aa
 aa
 aa
@@ -55386,7 +55513,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 mD
 mD
 tu
@@ -55397,20 +55524,20 @@ wu
 xh
 wu
 mD
-mD
+Km
 tc
-oe
-nU
-oe
+Up
+VG
+Up
 tc
 tc
-mD
-mD
-mD
-mD
-mD
-mD
-mD
+Km
+Km
+Km
+Km
+Km
+Km
+Km
 aa
 aa
 aa
@@ -55637,13 +55764,13 @@ aa
 aa
 aa
 aa
-mD
-oe
-oe
-mD
-oe
-oe
-mD
+Km
+Up
+Up
+Km
+Up
+Up
+Km
 rr
 sw
 sw
@@ -55661,7 +55788,7 @@ rc
 Bu
 BZ
 Cq
-mD
+Km
 aa
 aa
 aa
@@ -55894,7 +56021,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 of
 oA
 oX
@@ -55918,7 +56045,7 @@ pg
 pg
 pg
 Cr
-mD
+Km
 aa
 aa
 aa
@@ -56151,7 +56278,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 og
 oB
 oY
@@ -56175,7 +56302,7 @@ Pj
 Bv
 pg
 Cs
-qR
+RB
 aa
 aa
 aa
@@ -56408,7 +56535,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 oh
 oC
 oZ
@@ -56432,7 +56559,7 @@ rY
 rZ
 pg
 Ct
-nT
+WZ
 aa
 aa
 aa
@@ -56665,7 +56792,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 oi
 oD
 pa
@@ -56689,7 +56816,7 @@ zA
 sc
 zA
 Cu
-nU
+VG
 aa
 aa
 aa
@@ -56919,10 +57046,10 @@ aa
 aa
 aa
 aa
-mD
+Km
 ni
 nA
-mD
+Km
 oj
 oE
 pb
@@ -56946,7 +57073,7 @@ AL
 Bx
 sw
 Cv
-mD
+Km
 aa
 aa
 aa
@@ -57176,7 +57303,7 @@ aa
 aa
 aa
 aa
-mE
+Rr
 nj
 nB
 nS
@@ -57203,7 +57330,7 @@ AM
 By
 Ca
 Cw
-mD
+Km
 aa
 aa
 aa
@@ -57219,20 +57346,20 @@ aa
 aa
 aa
 aa
-Ep
-Ep
-Ep
-Ep
-Iv
-Iv
-Iv
-Iv
-Iv
-Iv
-Iv
-Iv
-Iv
-Iv
+Qr
+Qr
+Qr
+Qr
+IO
+IO
+IO
+IO
+IO
+IO
+IO
+IO
+IO
+IO
 aa
 aa
 aa
@@ -57433,7 +57560,7 @@ aa
 aa
 aa
 aa
-mD
+Km
 nk
 nC
 mD
@@ -57460,7 +57587,7 @@ AN
 Bz
 Cb
 Cx
-mD
+Km
 aa
 aa
 aa
@@ -57476,7 +57603,7 @@ aa
 aa
 aa
 aa
-Ep
+Qr
 EG
 EH
 Ev
@@ -57489,7 +57616,7 @@ Iw
 IR
 Jd
 Jn
-Iv
+IO
 aa
 aa
 aa
@@ -57690,10 +57817,10 @@ aa
 aa
 aa
 aa
-mD
-mD
-mD
-nT
+Km
+Km
+Km
+WZ
 om
 oH
 pd
@@ -57717,23 +57844,23 @@ AO
 BA
 Ca
 Cy
-mD
+Km
 aa
 aa
 aa
 aa
 aa
-Ep
-Ep
-Ep
-Ep
-Ep
-Ep
-Ep
-Ep
-Ep
-Ep
-Ep
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
 Ev
 Ev
 Ep
@@ -57746,7 +57873,7 @@ Iv
 Iv
 IR
 IR
-Iv
+IO
 aa
 aa
 aa
@@ -57950,7 +58077,7 @@ aa
 aa
 aa
 aa
-nU
+VG
 on
 oI
 pe
@@ -57974,13 +58101,13 @@ AP
 Ah
 sw
 Cz
-mD
+Km
 aa
 aa
 aa
 aa
 aa
-Ep
+Qr
 Fm
 FD
 Gb
@@ -58003,7 +58130,7 @@ WJ
 IS
 JG
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -58207,17 +58334,17 @@ aa
 aa
 aa
 aa
-mD
+Km
 mE
 oJ
 mD
 mD
 mD
-mD
-rz
+Km
+UW
 sD
-mD
-nU
+Km
+VG
 mD
 mD
 su
@@ -58231,13 +58358,13 @@ zA
 sw
 zA
 CA
-mD
+Km
 aa
 aa
 aa
 aa
 aa
-Ep
+Qr
 Fn
 FE
 Gc
@@ -58260,9 +58387,9 @@ WJ
 IS
 JG
 JG
-Iv
-Kg
-Iv
+IO
+OF
+IO
 aa
 aa
 aa
@@ -58448,33 +58575,33 @@ aa
 aa
 aa
 aa
-iX
+XR
 jk
-jr
-iX
-jr
+Ke
+XR
+Ke
 jI
-iX
+XR
 aa
 aa
 aa
 aa
-iX
-iX
-mF
-jE
-iF
-mD
+XR
+XR
+Ze
+RY
+GB
+Km
 oo
 oI
 pf
 pN
 qj
-nU
+VG
 rr
 sE
 tD
-mD
+Km
 uY
 oe
 su
@@ -58488,13 +58615,13 @@ Ai
 Ai
 rz
 nU
-mD
+Km
 aa
 aa
 aa
 aa
 aa
-Ep
+Qr
 Fo
 FF
 Gd
@@ -58519,7 +58646,7 @@ JG
 JG
 JG
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -58716,7 +58843,7 @@ aa
 aa
 aa
 aa
-iX
+XR
 mb
 mG
 nl
@@ -58727,11 +58854,11 @@ oK
 pg
 pg
 qk
-qR
+RB
 rA
 sF
 tE
-nU
+VG
 uZ
 oe
 su
@@ -58745,13 +58872,13 @@ sw
 sw
 zD
 CB
-mD
+Km
 aa
 aa
 aa
 aa
-Ep
-Ep
+Qr
+Qr
 Ep
 Ep
 Ep
@@ -58776,7 +58903,7 @@ JG
 JO
 JG
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -58959,21 +59086,21 @@ aa
 aa
 aa
 aa
-iF
-iN
-iX
-iX
+GB
+Uk
+XR
+XR
 jm
 jr
 iX
 jr
 jK
-iX
-iX
-iX
-iX
-iN
-iF
+XR
+XR
+XR
+XR
+Uk
+GB
 mc
 mH
 nm
@@ -58984,11 +59111,11 @@ oL
 ph
 pO
 ql
-nT
+WZ
 rB
 sG
 tF
-mD
+Km
 uY
 oe
 su
@@ -59002,12 +59129,12 @@ sw
 sw
 sw
 CC
-mD
+Km
 aa
 aa
 aa
 aa
-Ep
+Qr
 EE
 Ep
 FG
@@ -59033,7 +59160,7 @@ Iv
 Iv
 JX
 JX
-Iv
+IO
 aa
 aa
 aa
@@ -59216,7 +59343,7 @@ aa
 aa
 aa
 aa
-iF
+GB
 iO
 iO
 jc
@@ -59241,11 +59368,11 @@ nU
 mD
 mD
 mD
-mD
-mD
+Km
+Km
 sH
-rz
-mD
+UW
+Km
 oe
 qR
 wA
@@ -59259,12 +59386,12 @@ AQ
 BB
 sw
 CD
-mD
+Km
 aa
 aa
 aa
 aa
-Eq
+Yc
 EF
 Eq
 FH
@@ -59290,9 +59417,9 @@ JH
 Iv
 JG
 JG
-Iv
-Iv
-Iv
+IO
+IO
+IO
 aa
 aa
 aa
@@ -59473,7 +59600,7 @@ aa
 aa
 aa
 aa
-iF
+GB
 iP
 iP
 jd
@@ -59498,11 +59625,11 @@ oM
 pi
 pP
 qm
-nU
+VG
 rC
 sI
 tG
-mD
+Km
 va
 oe
 su
@@ -59516,12 +59643,12 @@ AR
 BC
 sw
 CE
-mD
+Km
 aa
 aa
 aa
 aa
-Ep
+Qr
 Ev
 Ep
 FI
@@ -59549,7 +59676,7 @@ JG
 JG
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -59730,7 +59857,7 @@ aa
 aa
 aa
 aa
-iF
+GB
 iQ
 iY
 iY
@@ -59755,11 +59882,11 @@ mi
 pj
 nm
 qm
-qR
+RB
 rD
 sJ
 tH
-mD
+Km
 vb
 oe
 su
@@ -59773,12 +59900,12 @@ sw
 sw
 sw
 CF
-nT
+WZ
 aa
 aa
 aa
 aa
-Ep
+Qr
 EG
 Ev
 FH
@@ -59806,7 +59933,7 @@ JG
 JG
 IR
 KB
-Iv
+IO
 aa
 aa
 aa
@@ -60012,11 +60139,11 @@ iR
 iY
 lo
 mg
-nT
+WZ
 rE
 sw
 tI
-mD
+Km
 va
 oe
 wB
@@ -60030,12 +60157,12 @@ AS
 BD
 pR
 CG
-mD
+Km
 aa
 aa
 aa
 aa
-Ep
+Qr
 EH
 Ev
 FI
@@ -60063,7 +60190,7 @@ JG
 JG
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -60269,11 +60396,11 @@ iR
 iY
 lo
 qn
-mD
-mD
-mD
-mD
-mD
+Km
+Km
+Km
+Km
+Km
 mD
 mD
 wu
@@ -60287,12 +60414,12 @@ mD
 mD
 rz
 nU
-mD
+Km
 Dq
-io
-io
-io
-Ep
+Xb
+Xb
+Xb
+Qr
 Ev
 Ep
 FH
@@ -60319,8 +60446,8 @@ Iv
 JG
 JG
 Iv
-Iv
-Iv
+IO
+IO
 aa
 aa
 aa
@@ -60501,7 +60628,7 @@ aa
 aa
 aa
 aa
-iF
+GB
 iR
 iY
 je
@@ -60576,7 +60703,7 @@ Iv
 Iv
 Kh
 Iv
-Iv
+IO
 aa
 aa
 aa
@@ -60833,7 +60960,7 @@ JP
 JZ
 JG
 Kn
-Iv
+IO
 aa
 aa
 aa
@@ -61091,8 +61218,8 @@ Ka
 JG
 Ko
 KC
-Iv
-Iv
+IO
+IO
 aa
 aa
 aa
@@ -61272,7 +61399,7 @@ aa
 aa
 aa
 aa
-iF
+GB
 iS
 iZ
 jf
@@ -61349,7 +61476,7 @@ JG
 Kp
 IR
 KG
-Iv
+IO
 aa
 aa
 aa
@@ -61529,7 +61656,7 @@ aa
 aa
 aa
 aa
-iF
+GB
 iF
 iN
 iF
@@ -61606,7 +61733,7 @@ JG
 Kq
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -61786,7 +61913,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -61863,7 +61990,7 @@ JG
 Kr
 Iv
 IR
-Iv
+IO
 aa
 aa
 aa
@@ -62043,7 +62170,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -62120,7 +62247,7 @@ JG
 Kc
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -62300,7 +62427,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -62377,7 +62504,7 @@ JG
 Ks
 IR
 KG
-Iv
+IO
 aa
 aa
 aa
@@ -62557,7 +62684,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -62634,7 +62761,7 @@ JG
 Kt
 KD
 IR
-Iv
+IO
 aa
 aa
 aa
@@ -62814,7 +62941,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -62891,7 +63018,7 @@ JG
 Ku
 IR
 KG
-Iv
+IO
 aa
 aa
 aa
@@ -63071,7 +63198,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -63148,7 +63275,7 @@ JG
 Kc
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -63328,7 +63455,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 aa
 aa
 aa
@@ -63405,7 +63532,7 @@ JG
 Kv
 Iv
 IR
-Iv
+IO
 aa
 aa
 aa
@@ -63582,10 +63709,10 @@ aa
 aa
 aa
 aa
-il
-il
-il
-il
+BU
+BU
+BU
+BU
 il
 il
 il
@@ -63662,7 +63789,7 @@ JG
 Kw
 IR
 KG
-Iv
+IO
 aa
 aa
 aa
@@ -63839,7 +63966,7 @@ aa
 aa
 aa
 aa
-il
+BU
 iq
 iA
 iH
@@ -63919,7 +64046,7 @@ JG
 Kx
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -64096,7 +64223,7 @@ aa
 aa
 aa
 aa
-il
+BU
 ir
 iB
 iI
@@ -64175,8 +64302,8 @@ Ka
 JG
 Ky
 KC
-Iv
-Iv
+IO
+IO
 aa
 aa
 aa
@@ -64353,7 +64480,7 @@ aa
 aa
 aa
 aa
-im
+CW
 is
 iC
 iJ
@@ -64431,7 +64558,7 @@ JP
 Kc
 JG
 Kn
-Iv
+IO
 aa
 aa
 aa
@@ -64610,7 +64737,7 @@ aa
 aa
 aa
 aa
-in
+RP
 it
 iC
 iK
@@ -64688,7 +64815,7 @@ Iv
 Iv
 Kh
 Iv
-Iv
+IO
 aa
 aa
 aa
@@ -64867,7 +64994,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 iu
 iu
 im
@@ -64945,8 +65072,8 @@ Iv
 JG
 JG
 Iv
-Iv
-Iv
+IO
+IO
 aa
 aa
 aa
@@ -65124,7 +65251,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 iv
 iD
 iD
@@ -65203,7 +65330,7 @@ JG
 JG
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -65381,7 +65508,7 @@ aa
 aa
 aa
 aa
-ip
+OI
 iw
 iC
 iC
@@ -65460,7 +65587,7 @@ JG
 JG
 IR
 KB
-Iv
+IO
 aa
 aa
 aa
@@ -65638,7 +65765,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 ix
 iE
 iE
@@ -65717,7 +65844,7 @@ JG
 JG
 IR
 KA
-Iv
+IO
 aa
 aa
 aa
@@ -65895,7 +66022,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 iu
 iu
 im
@@ -65972,9 +66099,9 @@ JL
 Iv
 JG
 JG
-Iv
-Iv
-Iv
+IO
+IO
+IO
 aa
 aa
 aa
@@ -66152,7 +66279,7 @@ aa
 aa
 aa
 aa
-in
+RP
 iy
 iC
 iL
@@ -66229,7 +66356,7 @@ Iv
 Iv
 JX
 JX
-Iv
+IO
 aa
 aa
 aa
@@ -66409,7 +66536,7 @@ aa
 aa
 aa
 aa
-im
+CW
 iz
 iC
 iM
@@ -66486,7 +66613,7 @@ JG
 JU
 JG
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -66666,7 +66793,7 @@ aa
 aa
 aa
 aa
-il
+BU
 ir
 iB
 iI
@@ -66743,7 +66870,7 @@ JG
 JG
 JG
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -66923,7 +67050,7 @@ aa
 aa
 aa
 aa
-il
+BU
 iq
 iA
 iH
@@ -67000,7 +67127,7 @@ JG
 JG
 Iv
 Kg
-Iv
+IO
 aa
 aa
 aa
@@ -67180,19 +67307,19 @@ aa
 aa
 aa
 aa
-il
-il
-il
-il
-il
-il
-il
-il
-il
-il
-il
-il
-il
+BU
+BU
+BU
+BU
+BU
+BU
+BU
+BU
+BU
+BU
+BU
+BU
+BU
 il
 il
 il
@@ -67257,7 +67384,7 @@ JG
 JG
 Iv
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -67449,7 +67576,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 io
 io
 io
@@ -67465,7 +67592,7 @@ ZV
 ZV
 ZV
 sR
-vr
+sR
 rT
 SY
 Wc
@@ -67514,7 +67641,7 @@ IR
 IR
 Iv
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -67706,7 +67833,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 mU
 nt
 nO
@@ -67771,7 +67898,7 @@ Jm
 Jr
 Iv
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -67963,7 +68090,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 ka
 km
 km
@@ -68020,15 +68147,15 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Iv
-Iv
-Iv
-Iv
-Iv
-Iv
+Qn
+IO
+IO
+IO
+IO
+IO
+IO
 JG
-Iv
+IO
 aa
 aa
 aa
@@ -68220,7 +68347,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 kb
 km
 km
@@ -68238,7 +68365,7 @@ sO
 rT
 rT
 rT
-yT
+yW
 zR
 uB
 ve
@@ -68277,15 +68404,15 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
 aa
 aa
-Iv
+IO
 Kj
-Iv
+IO
 aa
 aa
 aa
@@ -68477,7 +68604,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 iC
 km
 km
@@ -68534,7 +68661,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -68734,7 +68861,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 mV
 nu
 nP
@@ -68984,14 +69111,14 @@ aa
 aa
 aa
 aa
-io
-io
-io
-io
-io
-io
-io
-io
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
 io
 io
 io
@@ -69241,7 +69368,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 jZ
 iC
 kB
@@ -69265,7 +69392,7 @@ rP
 ZV
 tw
 rT
-wh
+wj
 yW
 zR
 uB
@@ -69305,7 +69432,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -69498,7 +69625,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 ka
 km
 km
@@ -69562,7 +69689,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -69755,7 +69882,7 @@ aa
 aa
 aa
 aa
-ip
+OI
 kb
 km
 kC
@@ -69779,7 +69906,7 @@ rP
 ZV
 tO
 rT
-wh
+wj
 yW
 zR
 uB
@@ -69819,7 +69946,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -70012,7 +70139,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 ka
 kl
 kD
@@ -70062,10 +70189,10 @@ Yn
 Yn
 Yn
 Yn
-Yn
+Qn
 wk
 wk
-Yn
+Qn
 Yn
 Yn
 Yn
@@ -70076,7 +70203,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -70269,7 +70396,7 @@ aa
 aa
 aa
 aa
-in
+RP
 kc
 kl
 kE
@@ -70319,10 +70446,10 @@ zM
 zM
 zM
 zs
-Yn
+Qn
 aa
 aa
-Yn
+Qn
 Pv
 Pv
 Pv
@@ -70526,7 +70653,7 @@ aa
 aa
 aa
 aa
-im
+CW
 kd
 kl
 kF
@@ -70576,10 +70703,10 @@ Se
 Se
 Se
 Tc
-Yn
+Qn
 aa
 aa
-Yn
+Qn
 Pm
 Pm
 Pm
@@ -70783,7 +70910,7 @@ aa
 aa
 aa
 aa
-in
+RP
 ke
 kl
 kG
@@ -70833,10 +70960,10 @@ Se
 Si
 Se
 Tc
-Yn
+Qn
 aa
 aa
-Yn
+Qn
 Xh
 Xh
 Pm
@@ -70847,7 +70974,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -71040,7 +71167,7 @@ aa
 aa
 aa
 aa
-im
+CW
 kf
 kl
 kH
@@ -71090,10 +71217,10 @@ Se
 Si
 Se
 Tc
-Yn
+Qn
 aa
 aa
-Yn
+Qn
 Xh
 Xh
 Pm
@@ -71104,7 +71231,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -71297,7 +71424,7 @@ aa
 aa
 aa
 aa
-in
+RP
 kg
 kl
 kE
@@ -71347,10 +71474,10 @@ Se
 Si
 Se
 Tc
-Yn
+Qn
 aa
 aa
-Yn
+Qn
 Pm
 Pm
 Pm
@@ -71361,7 +71488,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -71554,7 +71681,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 ka
 kl
 kD
@@ -71604,10 +71731,10 @@ Vk
 Vk
 Vk
 Oq
-Yn
+Qn
 aa
 aa
-Yn
+Qn
 Co
 Co
 Co
@@ -71618,7 +71745,7 @@ Yn
 NE
 NE
 NE
-Yn
+Qn
 aa
 aa
 aa
@@ -71811,7 +71938,7 @@ aa
 aa
 aa
 aa
-ip
+OI
 kb
 km
 kI
@@ -71850,31 +71977,31 @@ rb
 rb
 rb
 tV
-qV
-SY
-SY
-SY
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+MQ
+ub
+ub
+ub
+Qn
+Qn
+Qn
+Qn
+Qn
+Qn
+Qn
+Qn
 aa
 aa
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+Qn
+Qn
+Qn
+Qn
+Qn
+Qn
+Qn
+Qn
 XK
 XK
-Yn
+Qn
 aa
 aa
 aa
@@ -72068,7 +72195,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 ka
 km
 km
@@ -72121,7 +72248,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -72325,7 +72452,7 @@ aa
 aa
 aa
 aa
-io
+Xb
 kh
 kn
 kJ
@@ -72378,7 +72505,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -72582,21 +72709,21 @@ aa
 aa
 aa
 aa
-io
-io
-io
-io
-io
-io
-ip
-io
-io
-im
-ZV
-ZV
-ZV
-ZV
-ZV
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
+OI
+Xb
+Xb
+CW
+sV
+sV
+sV
+sV
+sV
 sV
 wq
 rb
@@ -72635,7 +72762,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -72839,7 +72966,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -72892,7 +73019,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -73096,7 +73223,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -73149,7 +73276,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -73353,7 +73480,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -73406,7 +73533,7 @@ aa
 aa
 aa
 aa
-aa
+UR
 aa
 aa
 aa
@@ -73610,6 +73737,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -73662,8 +73790,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -73867,6 +73994,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -73919,8 +74047,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -74124,6 +74251,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -74176,8 +74304,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -74381,6 +74508,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -74433,8 +74561,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -74638,6 +74765,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -74690,8 +74818,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -74895,6 +75022,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -74947,8 +75075,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -75152,6 +75279,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -75204,8 +75332,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -75409,6 +75536,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -75461,8 +75589,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -75666,6 +75793,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -75718,8 +75846,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -75923,6 +76050,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -75975,8 +76103,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -76180,6 +76307,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -76232,8 +76360,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -76437,6 +76564,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -76489,8 +76617,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -76694,6 +76821,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -76746,8 +76874,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -76951,6 +77078,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -77003,8 +77131,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -77208,6 +77335,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -77260,8 +77388,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -77465,6 +77592,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -77517,8 +77645,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -77722,6 +77849,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -77774,8 +77902,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -77979,6 +78106,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -78031,8 +78159,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -78236,6 +78363,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -78288,8 +78416,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -78493,6 +78620,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -78545,8 +78673,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -78750,6 +78877,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -78802,8 +78930,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -79007,6 +79134,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -79059,8 +79187,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -79264,6 +79391,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -79316,8 +79444,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -79521,6 +79648,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -79573,8 +79701,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -79778,6 +79905,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -79830,8 +79958,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -80035,6 +80162,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -80087,8 +80215,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -80292,6 +80419,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -80344,8 +80472,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -80549,6 +80676,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -80601,8 +80729,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -80806,6 +80933,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -80858,8 +80986,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -81063,6 +81190,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -81115,8 +81243,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -81320,6 +81447,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -81372,8 +81500,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -81577,6 +81704,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -81629,8 +81757,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -81834,6 +81961,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -81886,8 +82014,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -82091,6 +82218,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -82143,8 +82271,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -82348,6 +82475,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -82400,8 +82528,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -82605,6 +82732,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -82657,8 +82785,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -82862,6 +82989,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -82914,8 +83042,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -83119,6 +83246,7 @@ aa
 aa
 aa
 aa
+UR
 aa
 aa
 aa
@@ -83171,8 +83299,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+UR
 aa
 aa
 aa
@@ -83376,60 +83503,60 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
+UR
 aa
 aa
 aa

--- a/face/code/game/objects/effects/loot_spawners.dm
+++ b/face/code/game/objects/effects/loot_spawners.dm
@@ -2,7 +2,7 @@
 
 /obj/effect/spawner/lootdrop/snowdin/weaponrylite
 	name = "weaponry lite"
-	lootcount = 2
+	lootcount = 1
 	loot = list(/obj/item/melee/classic_baton = 20,
 				/obj/item/twohanded/fireaxe/fireyaxe = 20,
 				/obj/item/kitchen/knife/combat = 25,
@@ -24,7 +24,7 @@
 
 /obj/effect/spawner/lootdrop/snowdin/weaponrymid
 	name = "weaponry mid"
-	lootcount = 2
+	lootcount = 1
 	loot = list(/obj/item/shield/energy = 10,
 				/obj/item/gun/magic/wand/fireball = 10,
 				/obj/item/grenade/spawnergrenade/spesscarp = 10,
@@ -50,7 +50,7 @@
 
 /obj/effect/spawner/lootdrop/snowdin/weaponryheavy
 	name = "weaponry heavy"
-	lootcount = 2
+	lootcount = 1
 	loot = list(/obj/item/twohanded/singularityhammer = 5,
 				/obj/item/twohanded/mjollnir = 10,
 				/obj/item/melee/transforming/energy/axe = 5,


### PR DESCRIPTION
Placed bluespace shielding around the entire exterior of CentCom, including some airlocks. This does mean admins may have to remove some shields for ERT teams to use their ferry. Also cut back on the number of weapon spawners and reduced their loot count.

[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/brushtool/fpstation/blob/master/fpstation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:

tweak: Upgraded CentCom security
balance: Cut back on weaponry loot spawners at the CentCom dock
/:cl: