### PR TITLE
makes cult have a pop requirement

### DIFF
--- a/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/hippiestation/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -143,6 +143,7 @@
 /datum/dynamic_ruleset/roundstart/bloodcult
 	restricted_roles = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain", "Head of Personnel", "Vice Officer")
 	weight = 30
+	minimum_players = 10
 
 /datum/dynamic_ruleset/roundstart/infiltrator
 	name = "Infiltration Unit"


### PR DESCRIPTION
[Guidelines]: # None

## Changelog
:cl: Turret
tweak: Blood cult now has an actual pop requirement.
/:cl:

## About The Pull Request

makes blood cult have a pop requirement that's all

## Why It's Good For The Game

As shown by this: https://forums.hippiestation.com/viewtopic.php?f=7&t=2131

Lowpop blood cult sucks and will just result in the cultist murderboning everyone/sharding them but still being unable to spawn Nar'Sie. Changing the cap to 10 means that Nar'Sie will be able to be called and there will be a smaller chance of murderboners destroying everything.