### PR TITLE
Fixes messsaging server not working

### DIFF
--- a/_maps/map_files/FacepunchStation/facepunchstation.dmm
+++ b/_maps/map_files/FacepunchStation/facepunchstation.dmm
@@ -42674,7 +42674,7 @@
 	},
 /area/maintenance/strangeroom)
 "clm" = (
-/obj/machinery/telecomms/message_server,
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cln" = (


### PR DESCRIPTION
Fixes messaging server not working. Apparently our Tcomms room used an essentially blank messaging server, and not the preset it should start with.

[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/brushtool/fpstation/blob/master/fpstation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
fix: Fixed the station's messaging server not starting set up correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
