### PR TITLE
buffs the tin of beans because fuck it, shitty references

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -179,13 +179,14 @@
 	foodtype = MEAT | GRAIN
 
 /obj/item/reagent_containers/food/snacks/beans
-	name = "tin of beans"
+	name = "can of beans"
 	desc = "Musical fruit in a slightly less musical container."
 	icon_state = "beans"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 10)
 	filling_color = "#B22222"
 	tastes = list("beans" = 1)
+	throwforce = 20 // YOU JUST OPENED UP A GREAT BIG CAN OF WHOOP-ASS
 	foodtype = VEGETABLES
 
 /obj/item/reagent_containers/food/snacks/spidereggs


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/brushtool/fpstation/blob/master/fpstation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl:
tweak: Can of beans is now as powerful as a brick when thrown. You just opened up a great big can of whoop-ass.
/:cl:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
only one tin spawns on station and i love shitty references
