### PR TITLE
gets rid of hippie banner image

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -292,7 +292,7 @@ GLOBAL_VAR_INIT(tgs_initialized, FALSE)
 		s += "<br>Mode: <b>STARTING</b>"
 	if (hostedby)
 		s += "<br>Hosted by <b>[hostedby]</b>."
-	s += "<img src=\"https://i.imgur.com/xfWVypg.png\">" //Banner image
+	//s += "<img src=\"https://i.imgur.com/xfWVypg.png\">" Banner image
 
 	var/players = GLOB.clients.len
 


### PR DESCRIPTION
The hippiestation banner image shows up on the hub under us.

This deletes it cus we're not hippiestation 